### PR TITLE
Fix ShaderTraining device MLP parameter buffer offsets

### DIFF
--- a/src/NeuralShading/NeuralNetwork.cpp
+++ b/src/NeuralShading/NeuralNetwork.cpp
@@ -218,12 +218,28 @@ void NetworkUtilities::ConvertWeights(NetworkLayout const& srcLayout,
         weightDesc.src.type = GetNvrhiDataType(srcLayout.matrixPrecision);
         weightDesc.src.layout = GetNvrhiMatrixLayout(srcLayout.matrixLayout);
         weightDesc.src.size = srcLayer.weightSize;
+        if (srcLayout.matrixLayout == MatrixLayout::RowMajor)
+        {
+            weightDesc.src.stride = uint32_t(srcLayer.inputs * GetSize(srcLayout.matrixPrecision));
+		}
+        else if (srcLayout.matrixLayout == MatrixLayout::ColumnMajor)
+        {
+            weightDesc.src.stride = uint32_t(srcLayer.outputs * GetSize(srcLayout.matrixPrecision));
+		}
 
         weightDesc.dst.buffer = dstBuffer;
         weightDesc.dst.offset = dstBufferOffset + dstLayer.weightOffset;
         weightDesc.dst.type = GetNvrhiDataType(dstLayout.matrixPrecision);
         weightDesc.dst.layout = GetNvrhiMatrixLayout(dstLayout.matrixLayout);
         weightDesc.dst.size = dstLayer.weightSize;
+        if (dstLayout.matrixLayout == MatrixLayout::RowMajor)
+        {
+            weightDesc.dst.stride = uint32_t(dstLayer.inputs * GetSize(dstLayout.matrixPrecision));
+        }
+        else if (dstLayout.matrixLayout == MatrixLayout::ColumnMajor)
+        {
+            weightDesc.dst.stride = uint32_t(dstLayer.outputs * GetSize(dstLayout.matrixPrecision));
+		}
 
         nvrhi::coopvec::ConvertMatrixLayoutDesc& biasDesc = convertDescs.emplace_back();
 
@@ -235,12 +251,14 @@ void NetworkUtilities::ConvertWeights(NetworkLayout const& srcLayout,
         biasDesc.src.type = GetNvrhiDataType(srcLayout.matrixPrecision);
         biasDesc.src.layout = nvrhi::coopvec::MatrixLayout::RowMajor;
         biasDesc.src.size = srcLayer.biasSize;
+        biasDesc.src.stride = biasDesc.src.size;
 
         biasDesc.dst.buffer = dstBuffer;
         biasDesc.dst.offset = dstBufferOffset + dstLayer.biasOffset;
         biasDesc.dst.type = GetNvrhiDataType(dstLayout.matrixPrecision);
         biasDesc.dst.layout = nvrhi::coopvec::MatrixLayout::RowMajor;
         biasDesc.dst.size = dstLayer.biasSize;
+        biasDesc.src.stride = biasDesc.src.size;
     }
 
     commandList->convertCoopVecMatrices(convertDescs.data(), convertDescs.size());


### PR DESCRIPTION
I don't know if you accept pull requests from third parties but I have a small fix to a potential issue I noticed in the ShaderTraining sample, so this at least shows what I think the issue is.

When certain changes to the NetworkConfig is made (e.g. HIDDEN_NEURONS and NUM_HIDDEN_LAYERS), currently I bump into some issues. It would sometimes hang, and with certain modifications it is not able to load a saved model the way it was during training. Sometimes when loading a saved model, the output is different, maybe due to parameters being used outside the ranges that are read and written by ConvertWeights when saving/loading.

To me it looks like the weight and bias byte offsets passed to training and inference shaders, both using same buffer with training optimized layout, are actually the offsets as if it was still in row major layout of the host side buffer. I assume those should match the layout used in shader instead. Also the size of the device MLP buffers (both 32-bit and 16-bit) were based on the row major layout, which is a bit smaller.

I also added strides to the convert descs for row/column major layouts, although that did not seem to have any effect on the hardware I tested on.

These fixes can be helpful for trying to prototype some things on top of the ShaderTraining example as there would be issues when changing the parameters. Hopefully they are correct and I haven't just missed something, but it seems to make things more stable.