### PR TITLE
Fix compilation under Slang 26.7

### DIFF
--- a/src/NeuralShading_Shaders/Activation.slang
+++ b/src/NeuralShading_Shaders/Activation.slang
@@ -52,7 +52,8 @@ namespace mlp
         [Differentiable]
         CoopVec<T, K> eval(CoopVec<T, K> x)
         {
-            return no_diff CoopVec<T, K>(a) * x;
+            let aVec = no_diff CoopVec<T, K>(a);
+            return aVec * x;
         }
     };
 
@@ -73,7 +74,8 @@ namespace mlp
         [Differentiable]
         CoopVec<T, K> eval(CoopVec<T, K> x)
         {
-            return exp(x) - no_diff CoopVec<T, K>(T(1.));
+            let one = no_diff CoopVec<T, K>(T(1.));
+            return exp(x) - one;
         }
     };
 
@@ -121,7 +123,9 @@ namespace mlp
         [Differentiable]
         CoopVec<T, K> eval(CoopVec<T, K> x)
         {
-            return x / (no_diff CoopVec<T, K>(T(1.)) + exp(no_diff CoopVec<T, K>(T(-1.)) * x));
+            let one = no_diff CoopVec<T, K>(T(1.));
+            let negOne = no_diff CoopVec<T, K>(T(-1.));
+            return x / (one + exp(negOne * x));
         }
     };
 
@@ -131,8 +135,10 @@ namespace mlp
         [Differentiable]
         CoopVec<T, K> eval(CoopVec<T, K> x)
         {
-            var c1 = no_diff CoopVec<T, K>(T(1.));
-            return no_diff CoopVec<T, K>(T(2.)) / (c1 + exp(no_diff CoopVec<T, K>(T(-2.)) * x)) - c1;
+            let one = no_diff CoopVec<T, K>(T(1.));
+            let two = no_diff CoopVec<T, K>(T(2.));
+            let negTwo = no_diff CoopVec<T, K>(T(-2.));
+            return two / (one + exp(negTwo * x)) - one;
         }
     };
 }


### PR DESCRIPTION
Fixes following compilation bug under Slang 26.7
```
warning[E41016]: use of uninitialized variable
warning[E41016]: use of uninitialized variable
error[E41022]: derivative cannot be propagated through non-differentiable call
  --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:55:45
   |
55 | return no_diff CoopVec<T, K>(a) * x;
   |                                 ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
---'
error[E41022]: derivative cannot be propagated through non-differentiable call
  --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:76:27
   |
76 | return exp(x) - no_diff CoopVec<T, K>(T(1.));
   |               ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
---'
error[E41022]: derivative cannot be propagated through non-differentiable call
   --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:124:90
    |
124 | return x / (no_diff CoopVec<T, K>(T(1.)) + exp(no_diff CoopVec<T, K>(T(-1.)) * x));
    |                                                                              ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
----'
error[E41022]: derivative cannot be propagated through non-differentiable call
   --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:124:22
    |
124 | return x / (no_diff CoopVec<T, K>(T(1.)) + exp(no_diff CoopVec<T, K>(T(-1.)) * x));
    |          ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
----'
error[E41022]: derivative cannot be propagated through non-differentiable call
   --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:124:54
    |
124 | return x / (no_diff CoopVec<T, K>(T(1.)) + exp(no_diff CoopVec<T, K>(T(-1.)) * x));
    |                                          ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
----'
error[E41022]: derivative cannot be propagated through non-differentiable call
   --> /home/julcs/Developer/falcor-neural/build/linux-gcc/bin/Debug/shaders/RTXNS/Activation.slang:135:91
    |
135 | return no_diff CoopVec<T, K>(T(2.)) / (c1 + exp(no_diff CoopVec<T, K>(T(-2.)) * x)) - c1;
    |                                                                               ^ derivative cannot be propagated through call to non-backward-differentiable function ``, use 'no_diff' to clarify intention.
----'
```